### PR TITLE
Eliminating White Space

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -140,6 +140,10 @@ margin-bottom: 5px;
 }
   /* Carousel Start */
 
+  .carouselImage {
+    min-width: 100%;
+  }
+
   .carousel-item, .img-fluid {
     width: 100%;
     height: 100%;
@@ -372,14 +376,9 @@ hr {
           border-radius:15px;
           border-block-color: blue;
         }
-        .carousel-item{
 
-          margin: 1px;
-
-        }
         .cuisine-name{
           font-size: 66px;
-          margin: 1px;
         }
 
       }

--- a/assets/javascript/app.js
+++ b/assets/javascript/app.js
@@ -7,6 +7,31 @@ $(document).ready(function () {
 
   L.mapquest.key = mapQuestKey;
 
+  function fixCarousel() {
+    $(".carousel-item > img").each(function (i, img) {
+      $(img).css({
+        position: "relative",
+        left: ($(img).parent().width() - $(img).width()) / 2
+      });
+    });
+  };
+
+  fixCarousel();
+
+  $(window).resize(function () {
+    fixCarousel();
+  });
+
+  $("#carouselExampleIndicators").on("slid.bs.carousel", function () {
+    fixCarousel();
+  });
+
+  $("#carouselExampleIndicators").on("slide.bs.carousel", function () {
+    setTimeout(function () {
+      fixCarousel();
+  }, 1);
+  });
+
   $("#cuisine, #address").keyup(function (event) {
     if (event.keyCode === 13) {
       $("#search").click();
@@ -18,7 +43,7 @@ $(document).ready(function () {
     address = $("#address").val().trim();
 
     var cuisines = $('#cuisine').val().trim();
-    
+
     if (address === "") {
       $("#badInput").modal("show");
 

--- a/index.html
+++ b/index.html
@@ -51,39 +51,39 @@
           <li data-target="#carouselExampleIndicators" data-slide-to="4"></li>
           <li data-target="#carouselExampleIndicators" data-slide-to="5"></li>
         </ol>
-        <div class="carousel-inner">
+        <div class="carousel-inner text-center">
           <div class="carousel-item active">
-            <img class="d-block w-100" src="assets/images/italian.jpg" alt="First slide">
+            <img class="d-block carouselImage" src="assets/images/italian.jpg" alt="First slide">
             <div class="carousel-caption">
               <h1 class="cuisine-name">Italian</h1>
             </div>
           </div>
           <div class="carousel-item">
-            <img class="d-block w-100" src="assets/images/mexican.jpg" alt="Second slide">
+            <img class="d-block carouselImage" src="assets/images/mexican.jpg" alt="Second slide">
             <div class="carousel-caption">
               <h1 class="cuisine-name">Mexican</h1>
             </div>
           </div>
           <div class="carousel-item">
-            <img class="d-block w-100" src="assets/images/chinese.jpg" alt="Third slide">
+            <img class="d-block carouselImage" src="assets/images/chinese.jpg" alt="Third slide">
             <div class="carousel-caption">
               <h1 class="cuisine-name">Chinese</h1>
             </div>
           </div>
           <div class="carousel-item">
-            <img class="d-block w-100" src="assets/images/thai.jpg" alt="Fourth slide">
+            <img class="d-block carouselImage" src="assets/images/thai.jpg" alt="Fourth slide">
             <div class="carousel-caption">
               <h1 class="cuisine-name">Thai</h1>
             </div>
           </div>
           <div class="carousel-item">
-            <img class="d-block w-100" src="assets/images/indian.jpg" alt="Fifth slide">
+            <img class="d-block carouselImage" src="assets/images/indian.jpg" alt="Fifth slide">
             <div class="carousel-caption">
               <h1 class="cuisine-name">Indian</h1>
             </div>
           </div>
           <div class="carousel-item">
-            <img class="d-block w-100" src="assets/images/greek.jpg" alt="Fifth slide">
+            <img class="d-block carouselImage" src="assets/images/greek.jpg" alt="Fifth slide">
             <div class="carousel-caption">
               <h1 class="cuisine-name">Greek</h1>
             </div>


### PR DESCRIPTION
# Changes

* made carousel images fill all vertical space between header and footer

* made them always crop horizontally in order to achieve this without distorting the images

* used event listeners to trigger JavaScript that consistently re-positions the carousel images so that they're centered in the viewport when cropped horizontally

* eliminated code previously intended to solve the white space issue now that all of this stuff exists (in order to eliminate awkward white space around the carousel images in certain viewport sizes)